### PR TITLE
feat: Set UUID representation to STANDARD in MongoDB configuration

### DIFF
--- a/src/main/java/com/charity_hub/shared/infrastructure/MongoDBConfig.java
+++ b/src/main/java/com/charity_hub/shared/infrastructure/MongoDBConfig.java
@@ -7,6 +7,7 @@ import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
+import org.bson.UuidRepresentation;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
 import org.springframework.beans.factory.annotation.Value;
@@ -56,7 +57,8 @@ public class MongoDBConfig {
                         .build())
         );
 
-        settingsBuilder.codecRegistry(pojoCodecRegistry)
+        settingsBuilder.uuidRepresentation(UuidRepresentation.STANDARD)
+                .codecRegistry(pojoCodecRegistry)
                 .applyToConnectionPoolSettings(builder ->
                         builder.maxSize(4)
                                 .minSize(1)


### PR DESCRIPTION
This pull request updates the MongoDB configuration to explicitly set the UUID representation to `STANDARD`, which helps ensure consistent handling of UUIDs across the application. The change also adjusts the order in which codec registry and UUID representation are set in the MongoDB client settings.

**MongoDB Configuration Improvements:**

* Explicitly sets `UuidRepresentation.STANDARD` in the MongoDB client settings to ensure consistent UUID handling.
* Updates import statements to include `org.bson.UuidRepresentation` for the new configuration.